### PR TITLE
Add .github/workflows/issue-needs-triage-default-label.yml

### DIFF
--- a/.github/workflows/issue-needs-triage-default-label.yml
+++ b/.github/workflows/issue-needs-triage-default-label.yml
@@ -1,0 +1,18 @@
+name: issue-needs-triage-default-label
+
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: "needs triage"


### PR DESCRIPTION
Add a GitHub workflow that adds the "needs triage" label to all newly created issues.

https://docs.github.com/en/actions/managing-issues-and-pull-requests/adding-labels-to-issues