### PR TITLE
Bugfix: always treat `exam_at` as type datetime

### DIFF
--- a/app/Models/Deck.php
+++ b/app/Models/Deck.php
@@ -11,6 +11,10 @@ class Deck extends Model
 
     protected $fillable = ['name', 'description', 'exam_at', 'questions', 'module_id', 'is_archived'];
 
+    protected $casts = [
+        'exam_at' => 'datetime:Y-m-d',
+    ];
+
     public function questions()
     {
         return $this->belongsToMany(Question::class);

--- a/resources/views/deck-editor.blade.php
+++ b/resources/views/deck-editor.blade.php
@@ -27,7 +27,7 @@
             </div>
             <div class="mb-3">
                 <label for="exam_at" class="form-label">Exam date (optional)</label>
-                <input id="exam_at" type="date" name="exam_at" class="form-control" value="{{ $deck->exam_at ?? '' }}">
+                <input id="exam_at" type="date" name="exam_at" class="form-control" value="{{ optional($deck->exam_at)->format('Y-m-d') ?? '' }}">
             </div>
             <div class="mb-3">
                 <label for="description" class="form-label">Description (optional)</label>


### PR DESCRIPTION
Regression from #737

Without this change, `exam_at` will be treated as string and e.g.  `...->exam_at->format...` will throw an error (I thought I checked this in the original PR but seemingly I didn't)