### PR TITLE
Add clockwork to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,12 @@
         "socialiteproviders/keycloak": "^5.1"
     },
     "require-dev": {
-        "spatie/laravel-ignition": "^2.0",
         "fakerphp/faker": "^1.9.1",
+        "itsgoingd/clockwork": "^5.2",
         "mockery/mockery": "^1.4.2",
         "nunomaduro/collision": "^7.1",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^10.0",
+        "spatie/laravel-ignition": "^2.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "095edb0199370bacbef6c7cf72ead103",
+    "content-hash": "941fdca8014d59642f27600deb78bb6d",
     "packages": [
         {
             "name": "brick/math",
@@ -6201,6 +6201,81 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
             },
             "time": "2020-07-09T08:09:16+00:00"
+        },
+        {
+            "name": "itsgoingd/clockwork",
+            "version": "v5.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/itsgoingd/clockwork.git",
+                "reference": "df52c7c4d8d60443ea1d14bcf9b182d4eaaeec26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/itsgoingd/clockwork/zipball/df52c7c4d8d60443ea1d14bcf9b182d4eaaeec26",
+                "reference": "df52c7c4d8d60443ea1d14bcf9b182d4eaaeec26",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.6"
+            },
+            "suggest": {
+                "ext-pdo": "Needed in order to use a SQL database for metadata storage",
+                "ext-pdo_mysql": "Needed in order to use MySQL for metadata storage",
+                "ext-pdo_postgres": "Needed in order to use Postgres for metadata storage",
+                "ext-pdo_sqlite": "Needed in order to use a SQLite for metadata storage",
+                "ext-redis": "Needed in order to use Redis for metadata storage"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Clockwork\\Support\\Laravel\\ClockworkServiceProvider"
+                    ],
+                    "aliases": {
+                        "Clockwork": "Clockwork\\Support\\Laravel\\Facade"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Clockwork\\": "Clockwork/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "itsgoingd",
+                    "email": "itsgoingd@luzer.sk",
+                    "homepage": "https://twitter.com/itsgoingd"
+                }
+            ],
+            "description": "php dev tools in your browser",
+            "homepage": "https://underground.works/clockwork",
+            "keywords": [
+                "Devtools",
+                "debugging",
+                "laravel",
+                "logging",
+                "lumen",
+                "profiling",
+                "slim"
+            ],
+            "support": {
+                "issues": "https://github.com/itsgoingd/clockwork/issues",
+                "source": "https://github.com/itsgoingd/clockwork/tree/v5.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/itsgoingd",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-02-20T22:36:44+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/docs/development.md
+++ b/docs/development.md
@@ -161,6 +161,16 @@ sources and trigger a rebuild whenever you made a change. This way you can
 jump back and forth between your editor and the browser and instantly see
 the result of your changes.
 
+After installing [clockwork](https://underground.works/clockwork/) from the 
+dev dependencies (which should happen automatically) you can see the data
+collected for each request by visiting `http://[your-omc-domain]/clockwork`
+or by using the clockwork browser extension (for [Chrome](https://chrome.google.com/webstore/detail/clockwork/dmggabnehkmmfmdffgajcflpdjlnoemp) 
+or [Firefox](https://addons.mozilla.org/en-US/firefox/addon/clockwork-dev-tools/)).
+You can use the collected data to analyze the performance of the application
+or eventual changes you make including a deeper look into the database queries.
+Clockwork only works while the application is in debug mode and is using a local
+domain.
+
 ## Updating dependencies
 
 ### PHP / Composer


### PR DESCRIPTION
This adds [clockwork](https://underground.works/clockwork/) to the development requirements for composer. This adds the possibility to view
 php dev tools and insights in the request processing in the browser
 using the clockwork browser addon.