### PR TITLE
Make deck's `access` attribute editable and set default to 'private'

### DIFF
--- a/app/Http/Controllers/Api/DeckQuestionController.php
+++ b/app/Http/Controllers/Api/DeckQuestionController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
 use App\Models\Deck;
@@ -12,12 +13,20 @@ class DeckQuestionController extends Controller
 {
     public function index(Deck $deck)
     {
+        abort_if($deck->access == "private" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 404);
+
         $questions = $deck->questions()->with('answers', 'images')->get();
+
         return response()->json($questions);
     }
 
     public function store(Request $request, Deck $deck)
     {
+        // Decks with access "private" or "public-ro" can only
+        // be updated by their owner or an admin
+        abort_if($deck->access == "private" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 404);
+        abort_if($deck->access == "public-ro" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 403);
+
         if ($request->id) {
             $question = Question::findOrFail($request->id)->get();
         } else {
@@ -39,6 +48,11 @@ class DeckQuestionController extends Controller
 
     public function destroy(Deck $deck, Question $question)
     {
+        // Decks with access "private" or "public-ro" can only
+        // be updated by their owner or an admin
+        abort_if($deck->access == "private" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 404);
+        abort_if($deck->access == "public-ro" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 403);
+
         $deck->questions()->detach($question->id);
 
         if ($question->decks->isEmpty()) {

--- a/app/Http/Controllers/Api/SessionController.php
+++ b/app/Http/Controllers/Api/SessionController.php
@@ -33,11 +33,13 @@ class SessionController extends Controller
 
     public function store(Request $request)
     {
-        $newSession = new Session();
-
         $deck = Deck::findOrFail($request->deck_id);
 
+        abort_if($deck->access == "private" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 404);
+
         abort_if($deck->questions->isEmpty(), 400);
+
+        $newSession = new Session();
 
         $newSession->deck_id = $deck->id;
         $newSession->name = $deck->name;

--- a/app/Http/Controllers/DeckQuestionController.php
+++ b/app/Http/Controllers/DeckQuestionController.php
@@ -13,6 +13,8 @@ class DeckQuestionController extends Controller
 {
     public function show(Deck $deck, Question $question)
     {
+        abort_if($deck->access == "private" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 404);
+
         $questions = $deck->questions()->orderBy('id', 'asc')->get();
 
         $question->load('answers', 'images');
@@ -44,6 +46,9 @@ class DeckQuestionController extends Controller
 
     public function edit(Deck $deck)
     {
+        abort_if($deck->access == "private" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 404);
+        abort_if($deck->access == "public-ro" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 403);
+
         return view('deck-question-editor', ['deck' => $deck]);
     }
 }

--- a/app/Http/Controllers/SessionController.php
+++ b/app/Http/Controllers/SessionController.php
@@ -22,11 +22,13 @@ class SessionController extends Controller
 
     public function store(Request $request)
     {
-        $newSession = new Session();
-
         $deck = Deck::findOrFail($request->deck_id);
 
+        abort_if($deck->access == "private" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 404);
+
         abort_if($deck->questions->isEmpty(), 400);
+
+        $newSession = new Session();
 
         $newSession->deck_id = $deck->id;
         $newSession->name = $deck->name;

--- a/database/migrations/2024_03_13_221040_deck_make_access_default_private.php
+++ b/database/migrations/2024_03_13_221040_deck_make_access_default_private.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('decks', function (Blueprint $table) {
+            $table->string('access', 100)->default('private')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('decks', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/views/deck-editor.blade.php
+++ b/resources/views/deck-editor.blade.php
@@ -30,6 +30,27 @@
                 <input id="exam_at" type="date" name="exam_at" class="form-control" value="{{ optional($deck->exam_at)->format('Y-m-d') ?? '' }}">
             </div>
             <div class="mb-3">
+                <label for="access" class="form-label">Access</label>
+                @if ($deck->access == 'public-rw-listed')
+                    <input type="hidden" id="access" name="access" value="public-rw-listed">
+                    <select id="access" name="access" class="form-select" disabled>
+                        <option value="public-rw-listed" selected>public-rw-listed</option>
+                    </select>
+                @else
+                    <select id="access" name="access" class="form-select">
+                        @foreach (['private', 'public-ro', 'public-rw'] as $access)
+                            <option value="{{ $access }}" {{ ($deck->access == $access) ? 'selected' : '' }}>{{ $access }}</option>
+                        @endforeach
+                    </select>
+                @endif
+                <div class="form-text">
+                    Access can be <i>private</i> (only you can see this deck),
+                    <i>public-ro</i> (anyone can see this deck, but only you can edit it) or
+                    <i>public-rw</i> (anyone can see and edit this deck). If a deck is <i>public-rw-listed</i>,
+                    access cannot be changed.
+                </div>
+            </div>
+            <div class="mb-3">
                 <label for="description" class="form-label">Description (optional)</label>
                 <input type="hidden" id="description" name="description" value="{{ $deck->description ?? '' }}">
                 <trix-editor input="description"></trix-editor>

--- a/resources/views/deck.blade.php
+++ b/resources/views/deck.blade.php
@@ -69,14 +69,16 @@
             </div>
         @endif
 
-        <div class="row mb-3">
-            <div class="col-md mb-3">
-                <a href="/decks/{{ $deck->id }}/edit" class="btn btn-sm btn-outline-secondary w-100"><i class="bi bi-pencil"></i> Edit deck</a>
+        @if (Auth::user()->is_admin || $deck->user_id == Auth::id() || $deck->access == "public-rw" || $deck->access == "public-rw-listed")
+            <div class="row mb-3">
+                <div class="col-md mb-3">
+                    <a href="/decks/{{ $deck->id }}/edit" class="btn btn-sm btn-outline-secondary w-100"><i class="bi bi-pencil"></i> Edit deck</a>
+                </div>
+                <div class="col-md">
+                    <a href="/decks/{{ $deck->id }}/questions/edit" class="btn btn-sm btn-outline-secondary w-100"><i class="bi bi-pencil"></i> Add / remove questions</a>
+                </div>
             </div>
-            <div class="col-md">
-                <a href="/decks/{{ $deck->id }}/questions/edit" class="btn btn-sm btn-outline-secondary w-100"><i class="bi bi-pencil"></i> Add / remove questions</a>
-            </div>
-        </div>
+        @endif
 
     </div>
 </div>


### PR DESCRIPTION
So far the `access` attribute was mostly a stub and not yet editable by the user. Add a select element to the deck form to make it editable. Also change the default `access` to private so that user collections are private by default. Note that we don't plan to have private questions currently, i.e. only the collection of questions is private but not the contents of the individual questions in the deck.

Admins continue to be able to edit all decks, but we should add a warning to decks where the admin user isn't the owner to avoid accidental edits. (Will follow in a later commit.)

Also, add a few comments and extra lines to make the code more readable.