### PR TITLE
Add basic user management

### DIFF
--- a/app/Http/Controllers/UserManagementController.php
+++ b/app/Http/Controllers/UserManagementController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+use App\Models\User;
+
+class UserManagementController extends Controller
+{
+    public function index()
+    {
+        abort_unless(Auth::user()->is_admin, 403);
+        $users = User::filter(request(['search']))->paginate(25)->withQueryString();
+        return view('user-management', [
+            'users' => $users,
+        ]);
+    }
+
+    public function update(Request $request, $id)
+    {
+        abort_unless(Auth::user()->is_admin, 403);
+        $user = User::findOrFail($id);
+
+        $user->is_enabled = $request->is_enabled;
+        $user->save();
+
+        return back();
+    }
+
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,15 @@ class User extends Authenticatable
         });
     }
 
+    public function scopeFilter($query, array $filters)
+    {
+        $query->when($filters['search'] ?? false, function ($query, $search) {
+            $query->where('name', 'like', "%{$search}%'")
+                ->orWhere('public_name', 'like', "%{$search}%")
+                ->orWhere('email', 'like', "%{$search}%");
+        });
+    }
+
     /**
      * The attributes that are mass assignable.
      *
@@ -50,6 +59,7 @@ class User extends Authenticatable
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'last_login_at' => 'datetime',
     ];
 
     public function messages()

--- a/database/migrations/2024_03_24_164023_user_is_enabled_column.php
+++ b/database/migrations/2024_03_24_164023_user_is_enabled_column.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_enabled')->default(true);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2024_03_24_164042_user_last_login_column.php
+++ b/database/migrations/2024_03_24_164042_user_last_login_column.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('last_login_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -55,6 +55,7 @@
                                 @endif
                                 @if (Auth::user()->is_admin)
                                     <hr class="dropdown-divider">
+                                    <a class="dropdown-item" href="{{ url('admin/users') }}">User management</a>
                                     <a class="dropdown-item" href="{{ url('tokens') }}">API Token</a>
                                 @endif
                             </div>

--- a/resources/views/user-management.blade.php
+++ b/resources/views/user-management.blade.php
@@ -1,0 +1,61 @@
+@extends('layouts.app', [ 'container_class' => 'container'])
+
+@section('title', 'User Management')
+
+@section('content')
+    <div class="row">
+        <div class="col-md">
+            <h4>User management</h4>
+        </div>
+    </div>
+    <div class="row justify-content-end">
+        <div class="col-md-4">
+            <form action="/admin/users" method="get">
+                <div class="input-group mb-3">
+                    <input type="text" name="search" class="form-control" placeholder="Search users" value="{{ request('search') }}">
+                    <button class="btn btn-primary" type="submit">Search</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Public name</th>
+                <th>Email</th>
+                <th>Admin</th>
+                <th>Moderator</th>
+                <th>Created at</th>
+                <th>Last login</th>
+                <th>Enabled</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($users as $user)
+                <tr>
+                    <td>{{ $user->name }}</td>
+                    <td>{{ $user->public_name }}</td>
+                    <td>{{ $user->email }}</td>
+                    <td>{{ $user->is_admin ? 'y' : 'n' }}</td>
+                    <td>{{ $user->is_moderator ? 'y' : 'n' }}</td>
+                    <td>{{ $user->created_at->format('d.m.Y H:i:s') }}</td>
+                    <td>{{ optional($user->last_login_at)->format('d.m.Y H:i:s') ?? 'n/a' }}</td>
+                    <td>{{ $user->is_enabled ? 'y' : 'n' }}</td>
+                    <td>
+                        <form action="/admin/users/{{ $user->id }}" method="post">
+                            @method('put')
+                            @csrf
+                            <input type="hidden" name="is_enabled" value="{{ $user->is_enabled ? 0 : 1 }}" />
+                            <button class="btn btn-sm {{ $user->is_enabled ? 'btn-outline-primary' : 'btn-primary' }}" type="submit">
+                                {{ $user->is_enabled ? "Disable" : "Enable" }}
+                            </button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+    {{ $users->links() }}
+@endsection


### PR DESCRIPTION
This adds a basic user management table available for admins where they can toggle whether a user is enabled and view information for each user. The table will paginate and can be searched by email and name. This also disallows login for disabled users and records the time on each login (`last_login_at`).