### PR TITLE
[WIP/RFC] AppServiceProvider: configure `journal_mode=WAL` for sqlite

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Pagination\Paginator;
 
@@ -21,5 +22,11 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Paginator::useBootstrapFive();
+
+        if (DB::connection()->getDriverName() == 'sqlite') {
+            DB::connection()->getPdo()->exec('PRAGMA journal_mode=WAL');
+            DB::connection()->getPdo()->exec('PRAGMA synchronous=normal;');
+            DB::connection()->getPdo()->exec('PRAGMA temp_store=memory;');
+        }
     }
 }


### PR DESCRIPTION
There doesn't seem to be a way to configure SQLite pragmas like `journal_mode=WAL` from Laravel's database config (if there is a way, please let us know). Therefore, configure the SQLite database in the `AppServiceProvider` upon boot.

More infos on `journal_mode=WAL` and relevant pragma knobs for performance can be found under the links below:

https://www.sqlite.org/pragma.html#pragma_journal_mode

https://phiresky.github.io/blog/2020/sqlite-performance-tuning/

Resolves #759 (I think..)