### PR TITLE
Add `remember_me` expiration

### DIFF
--- a/app/Http/Controllers/UserSettingsController.php
+++ b/app/Http/Controllers/UserSettingsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 
 class UserSettingsController extends Controller
 {
@@ -51,5 +52,15 @@ class UserSettingsController extends Controller
     public function destroy(string $id)
     {
         //
+    }
+
+    public function invalidateDevices()
+    {
+        $user = Auth::user();
+
+        $user->setRememberToken(Str::random(60));
+        $user->save();
+
+        return back()->with('msg-success', 'Devices invalidated successfully.');
     }
 }

--- a/config/auth.php
+++ b/config/auth.php
@@ -39,6 +39,7 @@ return [
         'web' => [
             'driver' => 'session',
             'provider' => 'users',
+            'remember' => now()->addDays(7)->diffInMinutes(),
         ],
     ],
 

--- a/resources/views/user-settings.blade.php
+++ b/resources/views/user-settings.blade.php
@@ -27,6 +27,16 @@
 
             <button class="btn btn-sm btn-primary" type="submit">Save</button>
         </form>
+        <h4 class="mt-3">Security</h4>
+        <h6>Invalidate remembered devices</h6>
+        <form action="/me/settings/invalidate-devices" method="post">
+            @csrf
+            <button class="btn btn-sm btn-danger" type="submit">Invalidate devices</button>
+            <div class="form-text">
+                This forgets all devices that have been remembered with the "<i>Remain logged in</i>" option during log-in.
+                These devices will have to be logged in manually again.
+            </div>
+        </form>
     </div>
 </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -74,6 +74,7 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::get('/tokens', [TokenController::class, 'index'])->name('index.tokens');
 
     Route::get('/me/settings', [UserSettingsController::class, 'show']);
+    Route::post('/me/settings/invalidate-devices', [UserSettingsController::class, 'invalidateDevices']);
     Route::put('/me', [UserController::class, 'update']);
 
     Route::get('/admin/users', [UserManagementController::class, 'index']);


### PR DESCRIPTION
This adds both automated (via a cookie expiration) and manual (via user interaction) possibilities to invalidate / expire `remember_me` tokens that were previously set during login.