### PR TITLE
Save parent session for derived sessions

### DIFF
--- a/app/Http/Controllers/Api/SessionController.php
+++ b/app/Http/Controllers/Api/SessionController.php
@@ -74,6 +74,7 @@ class SessionController extends Controller
         $newSession->name = $deck->name;
         $newSession->current_question_id = $deck->questions()->first()->id;
         $newSession->user_id = Auth::id();
+        $newSession->parent_session_id = $session->id;
         $newSession->save();
 
         return response()->json($newSession);

--- a/app/Models/Session.php
+++ b/app/Models/Session.php
@@ -22,4 +22,9 @@ class Session extends Model
     {
         return $this->hasMany(AnswerChoice::class);
     }
+
+    public function parentSession()
+    {
+        return $this->belongsTo(Session::class, 'parent_session_id');
+    }
 }

--- a/database/migrations/2024_05_08_123029_sessions_parent_session_column.php
+++ b/database/migrations/2024_05_08_123029_sessions_parent_session_column.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('sessions', function (Blueprint $table) {
+            $table->bigInteger('parent_session_id')->unsigned()->nullable();
+            $table->foreign('parent_session_id')->references('id')->on('sessions');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION
This saves the parent session of derived sessions (e.g. "wrong answers from session x") in an additional database column.
Closes #763 