### PR TITLE
Save parent session for derived decks

### DIFF
--- a/app/Http/Controllers/Api/SessionController.php
+++ b/app/Http/Controllers/Api/SessionController.php
@@ -63,6 +63,7 @@ class SessionController extends Controller
         $deck->is_ephemeral = true;
         $deck->name = 'Repeat incorrect questions of session '. $session->id;
         $deck->user_id = Auth::id();
+        $deck->parent_session_id = $session->id;
 
         $deck->save();
 

--- a/app/Models/Deck.php
+++ b/app/Models/Deck.php
@@ -39,4 +39,9 @@ class Deck extends Model
     {
         return $this->hasOne(DeckSubmission::class);
     }
+
+    public function parentSession()
+    {
+        return $this->belongsTo(Session::class, 'parent_session_id');
+    }
 }

--- a/database/migrations/2024_05_19_154432_decks_parent_session_column.php
+++ b/database/migrations/2024_05_19_154432_decks_parent_session_column.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('decks', function (Blueprint $table) {
+            $table->bigInteger('parent_session_id')->unsigned()->nullable();
+            $table->foreign('parent_session_id')->references('id')->on('sessions');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION
This saves the parent session of derived decks (e.g. "wrong answers from session x") in an additional database column. Related to #763 and 4f38128cb85ee17f60971e9c5501f75aefe367c1