### PR TITLE
gitattributes: mark built JavaScript files as "binary"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *.scss linguist-vendored
 *.js linguist-vendored
 CHANGELOG.md export-ignore
+public/build/assets/* -diff


### PR DESCRIPTION
Our Svelte code gets transpiled into non-readable minimized JavaScript into `public/build/assets/*`. Mark the path as "binary" via gitattributes to make git not show the opaque minimized version in diff views.

https://git-scm.com/docs/gitattributes#_marking_files_as_binary