### PR TITLE
routes/web.php: Last login time for keycloak users

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -188,6 +188,9 @@ Route::get('/auth/keycloak/callback', function (Request $request) {
         $request->session()->regenerate();
     }
 
+    Auth::user()->last_login_at = Carbon::now();
+    Auth::user()->save();
+
     return redirect()->intended('/');
 });
 


### PR DESCRIPTION
This saves the `last_login_at` time for keycloak users like it is done for native users too.
Closes #929 