### PR TITLE
Kernel.php: Fix answer stats calculation

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -122,9 +122,11 @@ class Kernel extends ConsoleKernel
             if ($lastAnswerChoiceID) {
                 $answerChoices = AnswerChoice::select('id', 'question_id', 'answer_id')
                     ->where('id', '>', $lastAnswerChoiceID)
+                    ->whereHas('question', function ($query) {
+                        $query->where('type', 'mc');
+                    })
                     ->with(['question' => function ($query) {
                         $query->select('id')
-                            ->where('type', 'mc')
                             ->withCount('answer_choices')
                             ->with(['answers' => function ($query) {
                                 $query->select('id', 'question_id', 'answer_percentage')->withCount('answer_choices');
@@ -134,9 +136,11 @@ class Kernel extends ConsoleKernel
             } else {
                 $answerChoices = AnswerChoice::select('id', 'question_id', 'answer_id')
                     ->orderBy('id', 'desc')->limit(100)
+                    ->whereHas('question', function ($query) {
+                        $query->where('type', 'mc');
+                    })
                     ->with(['question' => function ($query) {
                         $query->select('id')
-                            ->where('type', 'mc')
                             ->withCount('answer_choices')
                             ->with(['answers' => function ($query) {
                                 $query->select('id', 'question_id', 'answer_percentage')->withCount('answer_choices');


### PR DESCRIPTION
In the scheduler for the answer stats calculation, only answer choices with related questions of the type MC should be retrieved by the database query. In the existing code, all answer choices would be queried, but only for those with MC type questions, the questions were eager-loaded. This lead to wrong answer choices being included in the collection and missing question objects.
This fixes this issue by actually only retrieving answer choices which are associated to questions of the type MC.