### PR TITLE
Models/User.php: Fix scope filter

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,7 +25,7 @@ class User extends Authenticatable implements MustVerifyEmail, CanResetPassword
     public function scopeFilter($query, array $filters)
     {
         $query->when($filters['search'] ?? false, function ($query, $search) {
-            $query->where('name', 'like', "%{$search}%'")
+            $query->where('name', 'like', "%{$search}%")
                 ->orWhere('public_name', 'like', "%{$search}%")
                 ->orWhere('email', 'like', "%{$search}%");
         });


### PR DESCRIPTION
The scope filter for the user model would not filter for the `name` attribute because of a typo. This commit fixes this.
Tested locally.