### PR TITLE
Api/DeckController: make sure case is attached to deck

### DIFF
--- a/app/Http/Controllers/Api/DeckController.php
+++ b/app/Http/Controllers/Api/DeckController.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
 use App\Models\Deck;
+use App\Models\Question;
 
 class DeckController extends Controller
 {
@@ -139,8 +140,12 @@ class DeckController extends Controller
         abort_if($deck->access == "private" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 404);
         abort_if($deck->access == "public-ro" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 403);
 
-        $question_id = $request->question_id;
-        $deck->questions()->attach($question_id);
+        $question = Question::findOrFail($request->question_id);
+        $deck->questions()->attach($question->id);
+
+        if ($question->case_id) {
+            $deck->cases()->syncWithoutDetaching($question->case_id);
+        }
 
         return response()->noContent();
     }


### PR DESCRIPTION
When a question with case gets added to a deck, we also have to attach the case to the deck, since we expect related cases to be loaded and be available in the deck editor.

Follow-up for 65e21e29796e271f288e2f1d7ed7cec2fe6a7fc0 ("Refactor deck and question editor").