### PR TITLE
Messages: Add boostraps `text-break` to divs

### DIFF
--- a/resources/js/MessageView.svelte
+++ b/resources/js/MessageView.svelte
@@ -130,7 +130,7 @@
             {#if !showEditor}
                 <div class="col-md offset-md-{indent}">
                     {#if !message.is_deleted}
-                        <p class="rounded-2 bg-light p-2 mb-0">
+                        <p class="rounded-2 bg-light p-2 mb-0 text-break">
                             {#if message.text}
                                 {@html DOMPurify.sanitize(message.text)}
                             {/if}

--- a/resources/js/Messages.svelte
+++ b/resources/js/Messages.svelte
@@ -160,7 +160,7 @@
                 action="#"
                 on:submit|preventDefault={handleSubmit}
                 class="mt-3 mb-3">
-                <div class="mb-3">
+                <div class="mb-3 text-break">
                     <input id="message" type="hidden" name="message" value="" />
                     <trix-editor input="message" />
                 </div>

--- a/resources/views/messages.blade.php
+++ b/resources/views/messages.blade.php
@@ -8,7 +8,7 @@
     <div class="col-md">
         <h4>Your comments</h4>
         @forelse($messages as $message)
-            <div class="rounded-2 bg-light p-2 mb-0">
+            <div class="rounded-2 bg-light p-2 mb-0 text-break">
                 {!! Purify::clean($message->text) !!}
             </div>
             <p class="text-muted text-end">


### PR DESCRIPTION
This adds bootstraps `text-break` to divs where message content is handled to prevent long strings of text (e.g. links) from overflowing their containers.