### PR TITLE
DeckController.php: Attach question only once

### DIFF
--- a/app/Http/Controllers/Api/DeckController.php
+++ b/app/Http/Controllers/Api/DeckController.php
@@ -141,7 +141,7 @@ class DeckController extends Controller
         abort_if($deck->access == "public-ro" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 403);
 
         $question = Question::findOrFail($request->question_id);
-        $deck->questions()->attach($question->id);
+        $deck->questions()->syncWithoutDetaching($question->id);
 
         if ($question->case_id) {
             $deck->cases()->syncWithoutDetaching($question->case_id);


### PR DESCRIPTION
When using `->attach($question->id)`, it is possible to attach one question to a deck multiple times because e.g. of missing UI feedback even though there is not a valid use case for this. Using `->syncWithoutDetaching($question->id)` solves this problem by not re-attaching the question if it is already attached to the deck.
Tested by sending the `[...]/addquestion` request multiple times using the Firefox devtools.
Closes #1022 