### PR TITLE
Use select optgroups to group modules into subjects

### DIFF
--- a/app/Http/Controllers/DeckController.php
+++ b/app/Http/Controllers/DeckController.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
 use App\Models\Deck;
-use App\Models\Module;
+use App\Models\Subject;
 
 class DeckController extends Controller
 {
@@ -71,13 +71,13 @@ class DeckController extends Controller
         abort_if($deck->access == "private" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 404);
         abort_if($deck->access == "public-ro" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 403);
 
-        $modules = Module::orderBy('name')->get();
+        $subjects = Subject::orderBy('name')->with('modules')->get();
         // Load the submission relationship to check if the deck has been submitted (used in template)
         $deck->load('submission');
 
         return view('deck-editor', [
             'deck' => $deck,
-            'modules' => $modules,
+            'subjects' => $subjects,
         ]);
     }
 

--- a/resources/views/deck-editor.blade.php
+++ b/resources/views/deck-editor.blade.php
@@ -32,8 +32,11 @@
                 <label for="module_id" class="form-label">Module (optional)</label>
                 <select id="module_id" name="module_id" class="form-select">
                     <option value="" selected>Select a module ...</option>
-                    @foreach ($modules as $module)
-                        <option value="{{ $module->id }}" {{ ($module->id == $deck->module_id) ? 'selected' : '' }}>{{ $module->name }}</option>
+                    @foreach ($subjects as $subject)
+                        <optgroup label="{{ $subject->name }}">
+                        @foreach ($subject->modules->sortBy('name') as $module)
+                            <option value="{{ $module->id }}" {{ ($module->id == $deck->module_id) ? 'selected' : '' }}>{{ $module->name }}</option>
+                        @endforeach
                     @endforeach
                 </select>
             </div>


### PR DESCRIPTION
Currently, the module list can be confusing and ambiguous, with many modules or when modules have the same name (for example, multiple subjects with a module "introduction").

Resolves #1012