### PR TITLE
Api/QuestionMessageController: load `public_name` if set

### DIFF
--- a/app/Http/Controllers/Api/QuestionMessageController.php
+++ b/app/Http/Controllers/Api/QuestionMessageController.php
@@ -55,7 +55,7 @@ class QuestionMessageController extends Controller
         $question->messages()->save($message);
 
         // Frontend expects author info in the message object
-        $message->load('author:id,name');
+        $message->load('author:id,name,public_name');
 
         // Load anonymized thumbs for this message to include in the response
         $message->thumbsAnonymized();


### PR DESCRIPTION
After storing a new comment, we have to load the user's `public_name` to make sure the frontend displays the public name instead of the username (if a public name is set). Otherwise it looks like a bug to users and as if the comment was stored with the real username instead of the public name.

Resolves #1032