### PR TITLE
Kernel.php: Fix answer distributions stats calc

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -132,7 +132,9 @@ class Kernel extends ConsoleKernel
                 ->limit(10)
                 ->with(['question' => function ($query) {
                     $query->select('id')
-                        ->withCount('answer_choices')
+                        ->withCount(['answer_choices' => function ($query) {
+                            $query->where('answer_id', '!=', null);
+                        }])
                         ->with(['answers' => function ($query) {
                             $query->select('id', 'question_id', 'answer_percentage')->withCount('answer_choices');
                         }]);


### PR DESCRIPTION
The answer distribution stats calculation produced unexpected results because it counted `answer_choices` without an `answer_id` into the question answer choices count. This fixes this by only counting answer choices with a `answer_id` for the question answer choices count.