### PR TITLE
README: fix link to CI workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # OpenMultipleChoice
 
-![](https://github.com/openmultiplechoice/openmultiplechoice/workflows/CI/badge.svg?branch=master)
+![](https://github.com/openmultiplechoice/openmultiplechoice/actions/workflows/ci.yml/badge.svg?branch=master)
 
 Status: alpha
 


### PR DESCRIPTION
a1d4021b2a7629f05990f620466253ebcd2f02a9 changed the README CI workflow badge to reflect the status for the master branch only, but the badge URL was wrong. Fix it.