### PR TITLE
Fix answer percentage calculation

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -123,6 +123,7 @@ class Kernel extends ConsoleKernel
 
             $answerChoices = AnswerChoice::select('id', 'question_id', 'answer_id')
                 ->where('id', '>', $lastAnswerChoiceID)
+                ->where('answer_id', '!=', null)
                 ->whereHas('question', function ($query) {
                     $query->where('type', 'mc');
                 })


### PR DESCRIPTION
The answer percentage can't be calculated for questions that were only answered by using "Show answer" (`answer_id` set to null) because the overall count of actual answer choices then is 0 and we cannot divide through 0 (`DivisionByZeroError`). Exclude answer choices without `answer_id` to fix this.
Closes #1070 