### PR TITLE
Sessions: verify access for linked deck

### DIFF
--- a/app/Http/Controllers/Api/SessionController.php
+++ b/app/Http/Controllers/Api/SessionController.php
@@ -122,6 +122,8 @@ class SessionController extends Controller
         }
 
         $deck = Deck::with('questions', 'cases', 'questions.images', 'questions.answers', 'questions.case')->find($session->deck_id);
+        abort_if($deck->access == "private" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 400);
+
         $session = $session->load('answerChoices');
 
         // If all questions have been removed from the

--- a/app/Http/Controllers/SessionController.php
+++ b/app/Http/Controllers/SessionController.php
@@ -59,8 +59,9 @@ class SessionController extends Controller
 
     public function show(Session $session)
     {
-        if (Auth::id() != $session->user_id) {
-            abort(404);
+        abort_if($session->user_id != Auth::id(), 404);
+        if ($session->deck->access == "private" && $session->deck->user_id != Auth::id()) {
+            return back()->with('msg-error', "Sorry, can't open this session since it links a private deck.");
         }
         return view('session', [
             'session' => $session,

--- a/tests/Feature/SessionsTest.php
+++ b/tests/Feature/SessionsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+use App\Models\Deck;
+use App\Models\User;
+use App\Models\Question;
+
+class SessionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $userA;
+    protected $userB;
+
+    protected $deckByA;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->userA = User::factory()->create();
+        $this->userB = User::factory()->create();
+
+        $this->deckByA = Deck::factory()->create([
+            'access' => 'public-ro',
+            'user_id' => $this->userA->id,
+        ]);
+
+        $this->deckByA->questions()->createMany([
+            Question::factory()->make()->toArray(),
+        ]);
+    }
+
+    public function testCanCreateSessionForPublicDeck(): void
+    {
+        $this->actingAs($this->userB)
+            ->postJson('/api/sessions', [
+                'deck_id' => $this->deckByA->id,
+            ])
+            ->assertStatus(200);
+    }
+
+    public function testCanOpenSessionLinkingPublicDeck(): void
+    {
+        $this->actingAs($this->userB)
+            ->from('/')
+            ->post('/sessions', [
+                'deck_id' => $this->deckByA->id,
+            ])->assertRedirectToRoute('show.session', [
+                'session' => 1,
+            ]);
+
+        $this->actingAs($this->userB)
+            ->getJson(url('/api/sessions', 1))
+            ->assertStatus(200);
+    }
+
+    public function testCannotCreateSessionForPrivateDeck(): void
+    {
+        $this->deckByA->access = 'private';
+        $this->deckByA->save();
+
+        $this->actingAs($this->userB)
+            ->postJson('/api/sessions', [
+                'deck_id' => $this->deckByA->id,
+            ])
+            ->assertStatus(404);
+
+        $this->actingAs($this->userB)
+            ->from('/')
+            ->post('/sessions', [
+                'deck_id' => $this->deckByA->id,
+            ])->assertStatus(404);
+    }
+
+    public function testCannotOpenSessionLinkingPrivateDeck(): void
+    {
+        $this->actingAs($this->userB)
+            ->postJson('/api/sessions', [
+                'deck_id' => $this->deckByA->id,
+            ])
+            ->assertStatus(200);
+
+        $this->deckByA->access = 'private';
+        $this->deckByA->save();
+
+        $this->actingAs($this->userB)
+            ->getJson(url('/api/sessions', 1))
+            ->assertStatus(400);
+
+        $response = $this->actingAs($this->userB)
+            ->from('/')
+            ->get(url('/sessions', [
+                'deck_id' => $this->deckByA->id,
+            ]));
+
+        $response->assertRedirectToRoute('index');
+        $response->assertSessionHas('msg-error', "Sorry, can't open this session since it links a private deck.");
+    }
+}


### PR DESCRIPTION
Before opening a session, ensure the user (still) has permission to access the linked deck. Otherwise, they could potentially access a private deck, such as when a previously public deck has been set to private.