### PR TITLE
resources/views/deck-editor: fix link to user decks

### DIFF
--- a/resources/views/deck-editor.blade.php
+++ b/resources/views/deck-editor.blade.php
@@ -105,7 +105,7 @@
             @elseif (!$deck->module)
                 Add this deck to a module to make it easier to find.
             @elseif ($deck->access == "public-ro" || $deck->access == "public-rw")
-                This deck is listed under <i>user decks</i> <a href="/sessions/create?module={{ $deck->module->id }}&kind=user">here</a>.
+                This deck is listed under <i>user decks</i> <a href="/sessions/create?module={{ $deck->module->id }}&kind=public">here</a>.
             @else
                 This deck is listed under <i>main decks</i> <a href="/sessions/create?module={{ $deck->module->id }}&kind=public-rw-listed">here</a>.
             @endif


### PR DESCRIPTION
The info message link should link the "User decks" listing (`kind=public`), since that is the link that works for all users where `kind=user` only works for the current owner of the deck.