### PR TITLE
Add indexes to answers and answer_choices tables

### DIFF
--- a/database/migrations/2025_02_03_225606_create_indexes_on_answers_and_answer_choices.php
+++ b/database/migrations/2025_02_03_225606_create_indexes_on_answers_and_answer_choices.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up()
+    {
+        Schema::table('answers', function (Blueprint $table) {
+            $table->index('question_id', 'idx_answers_question_id');
+        });
+
+        Schema::table('answer_choices', function (Blueprint $table) {
+            $table->index('answer_id', 'idx_answer_choices_answer_id');
+            $table->index('question_id', 'idx_answer_choices_question_id');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('answers', function (Blueprint $table) {
+            $table->dropIndex('idx_answers_question_id');
+        });
+
+        Schema::table('answer_choices', function (Blueprint $table) {
+            $table->dropIndex('idx_answer_choices_answer_id');
+            $table->dropIndex('idx_answer_choices_question_id');
+        });
+    }
+};


### PR DESCRIPTION
Add indexes to the `answers` and `answer_choices` tables for the columns
we frequently filter for or sort by, in particular when calculating the
answer distribution stats.

Follow-up for https://github.com/openmultiplechoice/openmultiplechoice/commit/68b8e328baa9e17c9cd728a59a31a370a27fc1e4

Resolves https://github.com/openmultiplechoice/openmultiplechoice/issues/1090