### PR TITLE
Paginate `/decks` listing

### DIFF
--- a/app/Http/Controllers/DeckBookmarkController.php
+++ b/app/Http/Controllers/DeckBookmarkController.php
@@ -8,10 +8,12 @@ use App\Models\Deck;
 
 class DeckBookmarkController extends Controller
 {
+    private const PAGE_SIZE = 30;
+
     public function index()
     {
         $user = Auth::user();
-        $bookmarkedDecks = $user->bookmarkedDecks()->paginate(10);
+        $bookmarkedDecks = $user->bookmarkedDecks()->paginate(self::PAGE_SIZE);
 
         return view('decks-bookmarks', ['bookmarked_decks' => $bookmarkedDecks]);
     }

--- a/app/Http/Controllers/DeckController.php
+++ b/app/Http/Controllers/DeckController.php
@@ -11,14 +11,30 @@ use App\Models\Subject;
 
 class DeckController extends Controller
 {
+    private const PAGE_SIZE = 30;
+
     public function index(Request $request)
     {
         $decks = Deck::where([
                 ['user_id', '=', Auth::id()],
                 ['access', '!=', 'public-rw-listed'],
                 ['is_ephemeral', '=', false],
-            ])->get();
+                ['is_archived', '=', false],
+            ])->orderBy('id', 'desc')->paginate(self::PAGE_SIZE);
+
         return view('decks', ['decks' => $decks]);
+    }
+
+    public function indexArchived(Request $request)
+    {
+        $decks = Deck::where([
+                ['user_id', '=', Auth::id()],
+                ['access', '!=', 'public-rw-listed'],
+                ['is_ephemeral', '=', false],
+                ['is_archived', '=', true],
+            ])->orderBy('id', 'desc')->paginate(self::PAGE_SIZE);
+
+        return view('decks-archived', ['decks' => $decks]);
     }
 
     public function store(Request $request)

--- a/resources/views/decks-archived.blade.php
+++ b/resources/views/decks-archived.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.app', [ 'container_class' => 'container'])
+
+@section('title', 'Decks')
+
+@section('content')
+
+<div class="row">
+    <div class="col-md">
+        <h4>Your archived decks</h4>
+    </div>
+</div>
+
+<div class="row">
+    @forelse ($decks as $deck)
+        @include('deck-col-element')
+    @empty
+        <div class="col-md">
+            <p>No archived decks</p>
+        </div>
+    @endforelse
+
+    <p>{{ $decks->links() }}</p>
+</div>
+
+@endsection

--- a/resources/views/decks.blade.php
+++ b/resources/views/decks.blade.php
@@ -40,7 +40,7 @@
 </div>
 
 <div class="row mb-3">
-    @forelse ($decks->filter(function ($d) { return !$d->is_archived; }) as $deck)
+    @forelse ($decks as $deck)
         @include('deck-col-element')
     @empty
         <div class="col-md">
@@ -49,20 +49,14 @@
     @endforelse
 </div>
 
-@php($archived_decks = $decks->filter(function ($d) { return $d->is_archived; }))
+<div class="row">
+    <div class="col-md">
+        <p>{{ $decks->links() }}</p>
 
-@if ($archived_decks->count() > 0)
-    <div class="row">
-        <div class="col-md">
-            <h4>Archived decks</h4>
+        <div class="alert alert-light">
+            You can find your archived decks <a href="/decks/archived" class="alert-link">here</a>.
         </div>
     </div>
-
-    <div class="row mb-3">
-        @foreach ($decks->filter(function ($d) { return $d->is_archived; }) as $deck)
-            @include('deck-col-element')
-        @endforeach
-    </div>
-@endif
+</div>
 
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,6 +59,7 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
         ]);
     })->name('index');
 
+    Route::get('/decks/archived', [DeckController::class, 'indexArchived']);
     Route::resource('/decks', DeckController::class);
     Route::get('/decks/{deck}/edit', [DeckController::class, 'edit'])->name('edit.deck');
 


### PR DESCRIPTION
Paginate the `/decks` listing and move the list of archived decks to a seperate page `/decks/archived`.

Also, use the same page size (30) for decks, bookmarked decks and archived decks.

Resolves #1109