### PR TITLE
Add sticky bottom links to pages with pagination

### DIFF
--- a/resources/views/decks-archived.blade.php
+++ b/resources/views/decks-archived.blade.php
@@ -19,7 +19,9 @@
         </div>
     @endforelse
 
-    <p>{{ $decks->links() }}</p>
+    <div class="sticky-bottom bg-white mt-3 pt-3">
+        {{ $decks->links() }}
+    </div>
 </div>
 
 @endsection

--- a/resources/views/decks-bookmarks.blade.php
+++ b/resources/views/decks-bookmarks.blade.php
@@ -19,7 +19,6 @@
             </div>
         @endforelse
     </div>
-    
     <div class="sticky-bottom bg-white mt-3 pt-3">
         {{ $bookmarked_decks->links() }}
     </div>

--- a/resources/views/decks-bookmarks.blade.php
+++ b/resources/views/decks-bookmarks.blade.php
@@ -19,7 +19,8 @@
             </div>
         @endforelse
     </div>
-    <div class="row">
+    
+    <div class="sticky-bottom bg-white mt-3 pt-3">
         {{ $bookmarked_decks->links() }}
     </div>
 

--- a/resources/views/decks.blade.php
+++ b/resources/views/decks.blade.php
@@ -51,12 +51,14 @@
 
 <div class="row">
     <div class="col-md">
-        <p>{{ $decks->links() }}</p>
-
         <div class="alert alert-light">
             You can find your archived decks <a href="/decks/archived" class="alert-link">here</a>.
         </div>
     </div>
+</div>
+
+<div class="sticky-bottom bg-white mt-3 pt-3">
+    {{ $decks->links() }}
 </div>
 
 @endsection

--- a/resources/views/magic-gifs.blade.php
+++ b/resources/views/magic-gifs.blade.php
@@ -53,8 +53,9 @@
                 @endforelse
             </tbody>
         </table>
-
-        <p>{{ $gifs->links() }}
+        <div class="sticky-bottom bg-white mt-3 pt-3">
+            {{ $gifs->links() }}
+        </div>
     </div>
 </div>
 

--- a/resources/views/messages.blade.php
+++ b/resources/views/messages.blade.php
@@ -21,7 +21,9 @@
             <p>No comments yet</p>
         @endforelse
 
-        <p>{{ $messages->links() }}</p>
+        <div class="sticky-bottom bg-white mt-3 pt-3">
+            {{ $messages->links() }}
+        </div>
     </div>
 </div>
 

--- a/resources/views/questions-reviewable.blade.php
+++ b/resources/views/questions-reviewable.blade.php
@@ -44,7 +44,7 @@
             @endforelse
         </div>
     </div>
-    <div class="row">
+    <div class="sticky-bottom bg-white mt-3 pt-3">
         {{ $questions->links() }}
     </div>
 @endsection

--- a/resources/views/registration-token.blade.php
+++ b/resources/views/registration-token.blade.php
@@ -90,10 +90,9 @@
         </table>
     </div>
 </div>
-<div class="row">
-    <div class="col">
-        {{ $tokens->links() }}
-    </div>
+
+<div class="sticky-bottom bg-white mt-3 pt-3">
+    {{ $tokens->links() }}
 </div>
 
 @endsection

--- a/resources/views/user-management.blade.php
+++ b/resources/views/user-management.blade.php
@@ -51,5 +51,8 @@
             @endforeach
         </tbody>
     </table>
-    {{ $users->links() }}
+
+    <div class="sticky-bottom bg-white mt-3 pt-3">
+        {{ $users->links() }}
+    </div>
 @endsection


### PR DESCRIPTION
Added sticky-bottom property to page links() on all the relevant pages with pagination that I could find based on issue: [Issue](https://github.com/openmultiplechoice/openmultiplechoice/issues/1124)
I also was able to test that they worked in the relevant pages, except I couldn't test the sticky bottom in the registration token view.
Let me know if I need to make any changes.