### PR TITLE
Messages: set `questionContext.isAnswered: true` for question views

### DIFF
--- a/public/build/assets/Messages-AGQ0OQAU.js
+++ b/public/build/assets/Messages-AGQ0OQAU.js
@@ -1,0 +1,1 @@
+import{M as t}from"./Messages-Dp-WrbKj.js";import"./index-C5hKwDc9.js";import"./each-JoEH9o9l.js";import"./purify.es-CzHI0FGf.js";import"./_commonjsHelpers-Cpj98o6Y.js";import"./UserSettingsStore-DIGhToub.js";import"./parseISO-nqt9u7wd.js";const e=document.getElementById("MessagesView");new t({target:e,props:{questionId:e.dataset.questionId,questionContext:{isAnswered:!0}}});

--- a/public/build/assets/Messages-x0Aq4OLa.js
+++ b/public/build/assets/Messages-x0Aq4OLa.js
@@ -1,1 +1,0 @@
-import{M as t}from"./Messages-Dp-WrbKj.js";import"./index-C5hKwDc9.js";import"./each-JoEH9o9l.js";import"./purify.es-CzHI0FGf.js";import"./_commonjsHelpers-Cpj98o6Y.js";import"./UserSettingsStore-DIGhToub.js";import"./parseISO-nqt9u7wd.js";const e=document.getElementById("MessagesView");new t({target:e,props:{questionId:e.dataset.questionId}});

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -158,7 +158,7 @@
     ]
   },
   "resources/js/Messages.js": {
-    "file": "assets/Messages-x0Aq4OLa.js",
+    "file": "assets/Messages-AGQ0OQAU.js",
     "name": "Messages",
     "src": "resources/js/Messages.js",
     "isEntry": true,

--- a/resources/js/Messages.js
+++ b/resources/js/Messages.js
@@ -6,5 +6,11 @@ const f = new Messages({
     target: messagesViewEl,
     props: {
         questionId: messagesViewEl.dataset.questionId,
+        // The Messages component loads comments for the question if the
+        // question is answered. `Messages.js` is used in question views
+        // where we want to show the comments right away.
+        questionContext: {
+            isAnswered: true,
+        },
     }
 });


### PR DESCRIPTION
Since 8565b2c455eb2a9955d22827e2c749373eda83da the Messages component uses the `questionContext.isAnswered` attribute to determine if comments should be displayed. Set `questionContext.isAnswered: true:` in Messages.js to show comments in the `question` and `deck-question` views.