### PR TITLE
github/workflows/ci: `git diff check` pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   linter:
@@ -87,3 +91,20 @@ jobs:
         run: |
           git add .
           git diff --staged --exit-code
+
+  verify-git-diff-check:
+    runs-on: ubuntu-latest
+
+    # Run job only if the workflow run was triggered by the pull_request event,
+    # as we need a base commit to diff against
+    if: ${{ github.event_name == 'pull_request' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: git diff check
+        run: |
+          git diff --check ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
Run `git diff --check <BASE>..HEAD` to "warn if changes introduce conflict markers or whitespace errors".

This changes the triggers for our GitHub CI workflow in order to not run jobs twice for pull requests, otherwise a push to a PR would trigger both 'push' and 'pull_request'. Instead, CI jobs will now be triggered on pull request events ('opened', 'synchronize', ...) and pushes to master but not for other branches and events.