### PR TITLE
resources/views/deck-editor: fix info message for archived decks

### DIFF
--- a/resources/views/deck-editor.blade.php
+++ b/resources/views/deck-editor.blade.php
@@ -14,6 +14,9 @@
             @if($deck->submission)
                 <span class="badge text-rounded-pill text-bg-warning mb-1 align-self-center text-uppercase">Submitted</span>
             @endif
+            @if($deck->is_archived)
+                <span class="badge text-rounded-pill text-bg-warning mb-1 align-self-center text-uppercase">Archived</span>
+            @endif
         </div>
         <form action="/decks/{{ isset($deck) ? $deck->id : '' }}" method="post" class="mb-3">
             @isset($deck)

--- a/resources/views/deck-editor.blade.php
+++ b/resources/views/deck-editor.blade.php
@@ -100,7 +100,9 @@
     <div class="col-md">
         <div class="alert alert-light">
             <i class="bi bi-info-circle me-2"></i>
-            @if ($deck->access == "private")
+            @if ($deck->is_archived)
+                This deck is archived. It is not listed but can be unarchived below.
+            @elseif ($deck->access == "private")
                 Set access to <i>public-ro</i> or <i>public-rw</i> to share this deck with others.
             @elseif (!$deck->module)
                 Add this deck to a module to make it easier to find.

--- a/resources/views/deck-question.blade.php
+++ b/resources/views/deck-question.blade.php
@@ -14,6 +14,9 @@
             @if($deck->submission)
                 <span class="badge text-rounded-pill text-bg-warning mb-1 align-self-center text-uppercase">Submitted</span>
             @endif
+            @if($deck->is_archived)
+                <span class="badge text-rounded-pill text-bg-warning mb-1 align-self-center text-uppercase">Archived</span>
+            @endif
         </div>
         <div class="d-grid gap-2 d-sm-block">
             <form action="{{ url('sessions') }}" method="POST" class="d-inline-grid">

--- a/resources/views/deck.blade.php
+++ b/resources/views/deck.blade.php
@@ -11,6 +11,9 @@
             @if($deck->submission)
                 <span class="badge text-rounded-pill text-bg-warning mb-1 align-self-center text-uppercase">Submitted</span>
             @endif
+            @if($deck->is_archived)
+                <span class="badge text-rounded-pill text-bg-warning mb-1 align-self-center text-uppercase">Archived</span>
+            @endif
         </div>
         <div class="d-grid gap-2 d-sm-block">
             @if (count($questions) > 0)


### PR DESCRIPTION
Currently, we show a message

    This deck is listed under ...

for public decks in a module that are archived, but archived decks are never listed. Instead, show a message

    This deck is archived. ...