### PR TITLE
DeckQuestionController: Fix prev/next navigation

### DIFF
--- a/app/Http/Controllers/DeckController.php
+++ b/app/Http/Controllers/DeckController.php
@@ -61,7 +61,8 @@ class DeckController extends Controller
     {
         abort_if($deck->access == "private" && $deck->user_id != Auth::id() && !Auth::user()->is_admin, 404);
 
-        $questions = $deck->questions()->orderBy('id', 'asc')->get();
+        // Load the questions contained in the deck, ordered by the pivot id (=time of addition to the deck)
+        $questions = $deck->questions()->get();
 
         $nextQuestion = $questions->first();
 

--- a/app/Http/Controllers/DeckQuestionController.php
+++ b/app/Http/Controllers/DeckQuestionController.php
@@ -23,8 +23,17 @@ class DeckQuestionController extends Controller
             abort(404);
         }
 
-        $prevQuestionId = $deck->questions()->where('questions.id', '<', $question->id)->max('questions.id');
-        $nextQuestionId = $deck->questions()->where('questions.id', '>', $question->id)->min('questions.id');
+        // Get the ordered questions from the relationship (ordered by pivot id)
+        $orderedQuestions = $deck->questions()->select('questions.id')->get();
+
+        // Find the current question's index in the ordered collection
+        $currentIndex = $orderedQuestions->search(function($item) use ($question) {
+            return $item->id === $question->id;
+        });
+
+        // Determine previous and next questions based on the ordered collection
+        $prevQuestionId = $orderedQuestions[$currentIndex - 1]->id ?? null;
+        $nextQuestionId = $orderedQuestions[$currentIndex + 1]->id ?? null;
 
         $urlPrev = null;
         if ($prevQuestionId) {


### PR DESCRIPTION
Decks and questions have a many-to-many relationship, the deck_question pivot table defines the order of questions for a deck and therefore questions (question IDs) are not strictly ascending from old to new (from lower to higher ID) but mixed, in the order of their addition to the deck.

This fixes the heuristic for finding the prev/next question in DeckQuestionController by picking the prev/next question based on the pivot table (i.e. order of addition to the deck) instead of using the next lower/higher question ID.
In DeckController, the approach used to order questions is clarified.

Fixes #1203