### PR TITLE
app/Http/Controllers/Api*: remove expensive validator rules

### DIFF
--- a/app/Http/Controllers/ApiAnswerChoiceController.php
+++ b/app/Http/Controllers/ApiAnswerChoiceController.php
@@ -19,8 +19,8 @@ class ApiAnswerChoiceController extends Controller
         }
 
         $validated = $request->validate([
-            'question_id' => 'required|integer|exists:questions,id',
-            'answer_id' => 'nullable|integer|exists:answers,id',
+            'question_id' => 'required|integer',
+            'answer_id' => 'nullable|integer',
             'help_used' => 'required|boolean',
             'is_correct' => 'required|boolean',
         ]);

--- a/app/Http/Controllers/ApiDeckController.php
+++ b/app/Http/Controllers/ApiDeckController.php
@@ -120,7 +120,7 @@ class ApiDeckController extends Controller
             'module_id' => 'nullable|integer|exists:modules,id',
             'access' => 'nullable|string|in:private,public-ro,public-rw,public-rw-listed',
             'question_ids' => 'nullable|array',
-            'question_ids.*' => 'integer|exists:questions,id',
+            'question_ids.*' => 'integer',
         ]);
 
         abort_if(($validated['access'] ?? null) == "public-rw-listed" && !Auth::user()->is_admin, 403);

--- a/app/Http/Controllers/ApiQuestionController.php
+++ b/app/Http/Controllers/ApiQuestionController.php
@@ -22,7 +22,7 @@ class ApiQuestionController extends Controller
         $validated = $request->validate([
             'text' => 'nullable|string|max:6000',
             'answers' => 'nullable|array',
-            'answers.*' => 'integer|exists:answers,id',
+            'answers.*' => 'integer',
         ]);
 
         $question = new Question();
@@ -71,7 +71,7 @@ class ApiQuestionController extends Controller
             'needs_review' => 'sometimes|boolean',
             'case_id' => 'sometimes|nullable|integer|exists:cases,id',
             'answers' => 'sometimes|nullable|array',
-            'answers.*.id' => 'required|integer|exists:answers,id',
+            'answers.*.id' => 'required|integer',
         ]);
 
         // Store the original correct_answer_id before filling the model with new data

--- a/app/Http/Controllers/ApiSessionController.php
+++ b/app/Http/Controllers/ApiSessionController.php
@@ -33,7 +33,7 @@ class ApiSessionController extends Controller
     public function store(Request $request)
     {
         $validated = $request->validate([
-            'deck_id' => 'required|integer|exists:decks,id',
+            'deck_id' => 'required|integer',
         ]);
 
         $deck = Deck::findOrFail($validated['deck_id']);
@@ -90,15 +90,12 @@ class ApiSessionController extends Controller
     {
         $validated = $request->validate([
             'question_ids' => 'required|array|min:1',
-            'question_ids.*' => 'integer|exists:questions,id',
+            'question_ids.*' => 'integer',
             'deck_name' => 'nullable|string|max:500',
             'module_id' => 'nullable|integer|exists:modules,id',
         ]);
 
         $questions = Question::findMany($validated['question_ids']);
-        if (!$questions) {
-            abort(400, 'No question IDs given');
-        }
 
         $deckName = $validated['deck_name'] ?? 'Repeat '. count($questions) .' incorrect questions';
 
@@ -169,7 +166,7 @@ class ApiSessionController extends Controller
         abort_if($session->user_id != Auth::id(), 404);
 
         $validated = $request->validate([
-            'current_question_id' => 'sometimes|nullable|integer|exists:questions,id',
+            'current_question_id' => 'sometimes|nullable|integer',
             'name' => 'sometimes|required|string|max:500',
         ]);
 


### PR DESCRIPTION
With 978f75403e8a78834fccd2812792ff3bb53900cb we added validators to all controller methods and added `required|integer|exists:...,id` rules where applicable to verify a passed integer value is actually a valid ID.

But this verification can be very expensive, especially in a hot path like `ApiAnswerChoiceController::store()` where we receive thousands of requests per hour on a busy installation, and doesn't bring a real benefit as invalid IDs will be rejected by the database due to foreign key constraints.

`ApiSessionController::newFromQuestionIds()` is not a hot path, but queries can include a large number of question IDs and the validation rule leads to one SELECT query for each of the passed IDs. Instead, only check if the passed values in `question_ids` are integer values and rely on the fact that Laravel's `findMany` silently returns only questions that exist. Also, remove an unnecessary check `if (!$questions) ...`, as `findMany` always returns a `Collection`.

The same reasoning applies to `ApiSessionController::update()` (called on every question turn, i.e. also a hot path) and other API controller methods.